### PR TITLE
Changed the way that the mainframe instance is assigned so that the launcher could run in release mode

### DIFF
--- a/Glowberry-Launcher.csproj
+++ b/Glowberry-Launcher.csproj
@@ -137,7 +137,7 @@
         </Content>
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="LaminariaCore-General" Version="1.1.1" />
+      <PackageReference Include="LaminariaCore-General" Version="1.1.2" />
       <PackageReference Include="LaminariaCore-Winforms" Version="1.0.1" />
       <PackageReference Include="Open.Nat" Version="2.1.0" />
       <PackageReference Include="System.Text.Json" Version="9.0.0-preview.2.24128.5" />

--- a/Program.cs
+++ b/Program.cs
@@ -22,24 +22,24 @@ namespace glowberry
             }
         }
 
-
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
         private static void Main()
         {
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
             Logging.Logger.LoggingFilePath = Path.Combine(Constants.FileSystem.AddSection("logs").SectionFullPath, Logging.Logger.LoggingSession + ".log");
             Logging.MinimumConsoleLoggingLevel = LoggingLevel.Info;
             Logging.MinimumFileLoggingLevel = LoggingLevel.Debug;
 
             try
             {
+                Application.EnableVisualStyles();
+                Application.SetCompatibleTextRenderingDefault(false);
+                
                 Application.Run(new PreLoadingScreen());
                 Application.Run(new LoadingScreen());
-                Application.Run(Mainframe.INSTANCE);
+                Application.Run(new Mainframe());
             }
             
             // Logs whatever fatal issue happens as a last resource.

--- a/ui/graphical/ConsoleInterface.cs
+++ b/ui/graphical/ConsoleInterface.cs
@@ -138,6 +138,8 @@ public partial class ConsoleInterface : Form
         string logsPath = this.ServerSection.GetFirstSectionNamed("logs").SectionFullPath;
         string latestLogPath = Directory.GetFiles(logsPath).OrderByDescending(File.GetLastWriteTime).FirstOrDefault();
         
+        Logging.Logger.Info("Starting console update task.");
+        
         while (true)
         {
             // Checks if the task has been cancelled
@@ -160,6 +162,7 @@ public partial class ConsoleInterface : Form
                 // Checks if the server is still running, and if not, writes a message to the console in red saying so.
                 if (!this.InteractionsAPI.IsRunning() || latestLogPath == null)
                 {
+                    Logging.Logger.Info("Tried to update console, but server is not running.");
                     SendConsoleError("This server is not running. Please start it and refresh the console.");
                     this.Invoke( new MethodInvoker( () => TextBoxServerInput.Enabled = false));
                     break;

--- a/ui/graphical/Mainframe.cs
+++ b/ui/graphical/Mainframe.cs
@@ -21,16 +21,17 @@ namespace glowberry.ui.graphical
         /// <summary>
         /// The singleton instance of the Mainframe.
         /// </summary>
-        public static Mainframe INSTANCE { get; } = new ();
+        public static Mainframe INSTANCE { get; set;  }
         
         /// <summary>
         /// Main constructor for the Mainframe. Loads up the server list. Private to enforce the
         /// singleton pattern.
         /// </summary>
-        private Mainframe()
+        public Mainframe()
         {
             InitializeComponent();
             MainLayout.SetAllFrom(NewServer.Instance.GetLayout());
+            INSTANCE = this;
         }
 
         /// <summary>


### PR DESCRIPTION
- This commit fixes the release mode not turnint on due to the compatible text rendering having to be called before any windows are; Since the mainframe was being statically loaded singleton-like, it was technically loaded first and thus the method failed.