### PR TITLE
Fixed a well known glitch with fatal errors not being caught

### DIFF
--- a/Glowberry-Launcher.csproj
+++ b/Glowberry-Launcher.csproj
@@ -39,7 +39,7 @@
     </PropertyGroup>
     <ItemGroup>
         <Reference Include="GlowberryDLL">
-          <HintPath>..\GlowberryDLL\bin\Release\GlowberryDLL.dll</HintPath>
+          <HintPath>..\GlowberryDLL\bin\Debug\GlowberryDLL.dll</HintPath>
         </Reference>
         <Reference Include="System" />
         <Reference Include="System.Configuration" />

--- a/Program.cs
+++ b/Program.cs
@@ -58,6 +58,7 @@ namespace glowberry
         {
             Logging.Logger.Info("Starting launcher session logging.");
             Logging.Logger.Info($"Glowberry Launcher Version: {Version}");
+            Logging.Logger.Info($"DLL Version: {GlobalVersionManager.GetVersion("dll")}");
             Logging.Logger.Info($"User Domain Name: {Environment.UserDomainName}");
             Logging.Logger.Info($"User Name: {Environment.UserName}");
             Logging.Logger.Info($"Process ID: {Process.GetCurrentProcess().Id}");

--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Configuration;
+using System.Diagnostics;
 using System.IO;
+using System.Threading;
 using System.Windows.Forms;
 using glowberry.common;
 using glowberry.common.configuration;
@@ -28,27 +30,70 @@ namespace glowberry
         [STAThread]
         private static void Main()
         {
-            Logging.Logger.LoggingFilePath = Path.Combine(Constants.FileSystem.AddSection("logs").SectionFullPath, Logging.Logger.LoggingSession + ".log");
-            Logging.MinimumConsoleLoggingLevel = LoggingLevel.Info;
-            Logging.MinimumFileLoggingLevel = LoggingLevel.Debug;
-
+            AppDomain.CurrentDomain.UnhandledException += FatalExceptionHandler;
+            Application.ThreadException += FatalExceptionHandler;
+            Application.SetUnhandledExceptionMode(UnhandledExceptionMode.ThrowException);
+            
             try
             {
+                Logging.Logger.LoggingFilePath = Path.Combine(Constants.FileSystem.AddSection("logs").SectionFullPath, Logging.Logger.LoggingSession + ".log");
+                Logging.MinimumConsoleLoggingLevel = LoggingLevel.Info;
+                Logging.MinimumFileLoggingLevel = LoggingLevel.Debug;
+                LogComputerInformation();
+                
                 Application.EnableVisualStyles();
                 Application.SetCompatibleTextRenderingDefault(false);
-                
+            
                 Application.Run(new PreLoadingScreen());
                 Application.Run(new LoadingScreen());
                 Application.Run(new Mainframe());
             }
-            
-            // Logs whatever fatal issue happens as a last resource.
-            catch (ConfigurationException e)
-            {
-                Logging.Logger.Fatal(@"An unexpected error occured and the program was forced to exit.");
-                Logging.Logger.Fatal(e.Message + "\n" + e.StackTrace, LoggingType.File);
-            }
+            catch (Exception e) { FatalExceptionHandler(null, e.Message); }
         }
         
+        /// <summary>
+        /// Logs the computer information to the log file.
+        /// </summary>
+        static void LogComputerInformation()
+        {
+            Logging.Logger.Info("Starting launcher session logging.");
+            Logging.Logger.Info($"Glowberry Launcher Version: {Version}");
+            Logging.Logger.Info($"User Domain Name: {Environment.UserDomainName}");
+            Logging.Logger.Info($"User Name: {Environment.UserName}");
+            Logging.Logger.Info($"Process ID: {Process.GetCurrentProcess().Id}");
+            Logging.Logger.Info($"OS Version: {Environment.OSVersion.Platform} {Environment.OSVersion}");
+            Logging.Logger.Info($"Available RAM Memory: {Environment.WorkingSet / 1024 / 1024} MB");
+            Logging.Logger.Info($"Available Logical Processors: {Environment.ProcessorCount}");
+        }
+        
+        /// <summary>
+        /// Handles the fatal exceptions that occur in the program for any unhandled exceptions.
+        /// </summary>
+        static void FatalExceptionHandler(object sender, UnhandledExceptionEventArgs e) => 
+            FatalExceptionHandler(sender, e.ExceptionObject.ToString());
+        
+        /// <summary>
+        /// Handles the thread exceptions that occur in the program for any unhandled exceptions.
+        /// </summary>
+        static void FatalExceptionHandler(object sender, ThreadExceptionEventArgs e) => 
+            FatalExceptionHandler(sender, e.Exception.Message);
+        
+        /// <summary>
+        /// Handles the fatal exceptions that occur in the program. This will log the error and prompt the user to open the
+        /// log file.
+        /// </summary>
+        /// <param name="sender">The event sender</param>
+        /// <param name="errorMessage">The error message to be printed in the file</param>
+        static void FatalExceptionHandler(object sender, string errorMessage)
+        {
+            Logging.Logger.Fatal(@"An unexpected error occured and the program was forced to exit.");
+            Logging.Logger.Fatal(errorMessage, LoggingType.File);
+
+            // Prompt the user to open the log file.
+            string message = "A fatal error has occured and the program was forced to exit.\nWould you like to open the log file?";
+            DialogResult result = MessageBox.Show(message, @"Glowberry - Fatal Error", MessageBoxButtons.YesNo, MessageBoxIcon.Error);
+            
+            if (result == DialogResult.Yes) Process.Start(Logging.Logger.LoggingFilePath);
+        }
     }
 }


### PR DESCRIPTION
- Added some exception handling with the registration of the `UnhandledExceptionEvent` and `ThreadException` for fatal errors, and a failsafe for every exception at the beginning.
- Added a general machine logging session marker for when the glowberry launcher runs